### PR TITLE
Resets the hangman game word once a user hits the game reset button

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -83,6 +83,8 @@ var hangmanGraphic = function () {
       resetAlphabetKeypad();
       removeGraveyardLetters();
       removeCorrectlyGuessedLetters();
+      clearHtmlAroundOldWord();
+      setWordToBeGuessed();
     }
   };
 }();
@@ -108,6 +110,10 @@ function removeCorrectlyGuessedLetters(){
   $('#word-to-guess').each(function(index, element){
     $(element).children().html('');
   });
+}
+
+function clearHtmlAroundOldWord(){
+  $("#word-to-guess").html('');
 }
 
 // adding dictionary and word filter //
@@ -139,24 +145,34 @@ function wordSelect (array) {
   return word;
 }
 
-var currentWordFull = wordSelect(hangmanWords);//IMPORTANT: replace the number with wordSelect (the function) for production use
+function setWordToBeGuessed(){
 
-//set an all upper case version of the current word
-var currentWord = currentWordFull.toUpperCase();
+  currentWordFull = wordSelect(hangmanWords);//IMPORTANT: replace the number with wordSelect (the function) for production use
 
-//creates blocks in the DOM indicating where there are letters and spaces
-currentWord.split("").map(function(character) {
-  var guessWordBlock = document.getElementById("word-to-guess");
+  //set an all upper case version of the current word
+  currentWord = currentWordFull.toUpperCase();
+  //creates blocks in the DOM indicating where there are letters and spaces
 
-  var domElem = document.createElement("div");
 
-  if (character.match(/[a-z]/i)) {
-    domElem.className = "character-block is-letter";
+  currentWord.split("").map(function(character) {
+    var guessWordBlock = document.getElementById("word-to-guess");
 
-  } else {
-    domElem.className = "character-block";
+    var domElem = document.createElement("div");
 
-  }
+    if (character.match(/[a-z]/i)) {
+      domElem.className = "character-block is-letter";
 
-  guessWordBlock.appendChild(domElem);
+    } else {
+      domElem.className = "character-block";
+    }
+
+    guessWordBlock.appendChild(domElem);
+  });
+}
+
+var currentWordFull;
+var currentWord;
+
+$(document).ready(function() {
+  setWordToBeGuessed();
 });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -73,7 +73,7 @@ var hangmanGraphic = function () {
       if (bodyParts < maxParts) {
         ++bodyParts;
         $("#hangman-frame" + bodyParts).css("opacity", 1);
-      } 
+      }
     },
 
     reset : function () {
@@ -83,7 +83,7 @@ var hangmanGraphic = function () {
       resetAlphabetKeypad();
       removeGraveyardLetters();
       removeCorrectlyGuessedLetters();
-      clearHtmlAroundOldWord();
+      removeFillInTheBlanksAroundOldWord();
       setWordToBeGuessed();
     }
   };
@@ -112,7 +112,7 @@ function removeCorrectlyGuessedLetters(){
   });
 }
 
-function clearHtmlAroundOldWord(){
+function removeFillInTheBlanksAroundOldWord(){
   $("#word-to-guess").html('');
 }
 
@@ -173,6 +173,4 @@ function setWordToBeGuessed(){
 var currentWordFull;
 var currentWord;
 
-$(document).ready(function() {
-  setWordToBeGuessed();
-});
+setWordToBeGuessed();


### PR DESCRIPTION
The reset game button didn't allow a user to guess a new word every time a user clicks on the reset button. This PR fixes this bug. The trello card for this bug can be found on [this link](https://trello.com/c/1ac7MZFc/52-reset-button-never-resets-the-word-it-just-clears-the-spaces).
