### PR TITLE
Disallows a user from continuing a game after a win or loss

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,28 +45,26 @@
 </div><!-- /.modal -->
 
 
-<div class="modal fade" id="congratulatory_message" role="dialog">
+<div class="modal fade" id="congratulatory_message" role="dialog" data-backdrop="static" data-keyboard="false">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
         <h4 class="modal-title">CONGRATULATIONS!</h4>
       </div>
       <div class="modal-body">
         <h5>Congratulations, you've won the game!!</h5>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button class="btn reset" data-dismiss="modal"> Close and Reset </button>
       </div>
     </div>
   </div>
 </div>
 
-<div class="modal fade" id="gameover_message" role="dialog">
+<div class="modal fade" id="gameover_message" role="dialog" data-backdrop="static" data-keyboard="false">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
         <h4 class="modal-title">You lost the game!</h4>
       </div>
       <div class="modal-body">
@@ -84,7 +82,7 @@
         </div><!--/.container-fluid-->
       </div><!--/.modal-body-->
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button class="btn reset" data-dismiss="modal"> Close and Reset </button>
       </div>
     </div>
   </div>
@@ -146,7 +144,7 @@
           Lose Life
           </button>
 
-          <button id="reset" class="btn btn-success">
+          <button class="btn btn-success reset">
           Reset
           </button>
         </div>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -92,7 +92,7 @@ var hangmanGraphic = function () {
 // Next 2 lines will be refactored into interface for
 //   losing a life and reseting the game
 $("#lose-life").on("click", hangmanGraphic.addBodyPart);
-$("#reset").on("click", hangmanGraphic.reset);
+$(".reset").on("click", hangmanGraphic.reset);
 
 function resetAlphabetKeypad(){
   $("#alphabet-keypad > .letter-disabled").each(function(index, element){


### PR DESCRIPTION
Some background behind this PR -
1. Until now, a user playing the game could continue playing even after a win or loss. This could happen after the user closes the bootstrap modal which had the win or loss display message. 
2. With the changes in this PR a user can't close a bootstrap modal by hitting the `esc` key or by clicking anywhere in the window outside the displayed current modal. The user would have to hit the `Close and Reset` button to start anew.
